### PR TITLE
Reorganize imports in broadcast.jl

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -1,6 +1,6 @@
-using DataArrays, Base.@get!
-using Base.Broadcast: bitcache_chunks, bitcache_size, dumpbitcache,
-                      promote_eltype, broadcast_shape
+using DataArrays
+using Base: @get!, promote_eltype
+using Base.Broadcast: bitcache_chunks, bitcache_size, dumpbitcache, broadcast_shape
 using Compat: promote_eltype_op
 
 if isdefined(Base, :OneTo)


### PR DESCRIPTION
`promote_eltype` is defined in `abstractarray.jl` in Base. Also, this will avoid problems if https://github.com/JuliaLang/julia/pull/17389 gets merged.
